### PR TITLE
Normalization fix

### DIFF
--- a/lib/dm-sqlite-adapter/adapter.rb
+++ b/lib/dm-sqlite-adapter/adapter.rb
@@ -19,10 +19,18 @@ module DataMapper
       def normalize_options(options)
         # TODO Once do_sqlite3 accepts both a Pathname or a String,
         # normalizing database and path won't be necessary anymore
-        db   = (options[:database] || options.delete('database')).to_s
-        path = (options[:path    ] || options.delete('path')).to_s
+        # Clean out all the 'path-like' parameters in the options hash
+        # ensuring there can only be one.
+        # Also make sure a blank value can't possibly mask a non-blank one
+        path = nil
+        [:path, 'path', :database, 'database'].each do |key|
+          db = options.delete(key)
+          unless db.nil? or db.empty?
+            path ||= db
+          end
+        end
 
-        options.update(:adapter => 'sqlite3', :database => db, :path => path)
+        options.update(:adapter => 'sqlite3', :path => path.to_s)
       end
 
     end

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -31,11 +31,26 @@ describe 'DataMapper::Adapters::SqliteAdapter' do
 
   describe "with 'database' given as Symbol" do
     subject { DataMapper::Adapters::SqliteAdapter.new(:default, { :adapter => 'sqlite', :database => :name }) }
-    it { subject.options[:database].should == 'name' }
+    it { subject.options[:path].should == 'name' }
   end
 
   describe "with 'path' given as Symbol" do
     subject { DataMapper::Adapters::SqliteAdapter.new(:default, { :adapter => 'sqlite', :path => :name }) }
+    it { subject.options[:path].should == 'name' }
+  end
+
+  describe "with 'database' given as String" do
+    subject { DataMapper::Adapters::SqliteAdapter.new(:default, { :adapter => 'sqlite', 'database' => :name }) }
+    it { subject.options[:path].should == 'name' }
+  end
+
+  describe "with 'path' given as String" do
+    subject { DataMapper::Adapters::SqliteAdapter.new(:default, { :adapter => 'sqlite', 'path' => :name }) }
+    it { subject.options[:path].should == 'name' }
+  end
+
+  describe "with blank 'path' and 'database' given as Symbol" do
+    subject { DataMapper::Adapters::SqliteAdapter.new(:default, { :adapter => 'sqlite', 'path' => '', :database => :name }) }
     it { subject.options[:path].should == 'name' }
   end
 


### PR DESCRIPTION
This pull request is to fix the inconsistent intention and actual behaviour shown in dm-sqlite-adapter and dm-do-adapter.  It also seems truer to the intentions of the commit message for 3e90a58e93.  The 'database' and 'path' config hash entries can now be used interchangeably, restoring the pre-1.0 behaviour and giving more consistency with the format of database.yml accepted by both ActiveRecord and Sequel.
